### PR TITLE
Add --show-missing option

### DIFF
--- a/get-data.py
+++ b/get-data.py
@@ -34,8 +34,26 @@ class Cli:
             print(f"Command '{' '.join(cmd)}' with exit code {e.returncode}: {e.stderr}")
             exit(1)
 
+def show_missing(args):
+    if not os.path.exists(args.header_csv):
+        print("Could not find csv file")
+        return 1
+
+    reader = csv.reader(open(args.header_csv, "r", newline=''))
+    next(reader, None)  # skip the headers
+    for height, bhash, header in reader:
+        if header == "":
+            print(f"Missing header {height} {bhash}")
+        else:
+            blockfile = f"{args.blocks_dir}/{height}-{bhash}.bin"
+            if not os.path.exists(blockfile):
+                print(f"Missing blockfile {height} {bhash}")
+
 def main(args):
     cli = Cli(args).cli
+
+    if args.show_missing:
+        show_missing(args)
 
     existing = {}
     if os.path.exists(args.header_csv):
@@ -107,6 +125,8 @@ def get_args(argv):
     parser.add_argument("--get-full-blocks", default=False, action="store_true")
     parser.add_argument("--blocks-dir", default="blocks", type=str)
     parser.add_argument("--header-csv", default="stale-blocks.csv", type=str)
+
+    parser.add_argument("--show-missing", default=False, action="store_true")
 
     return parser.parse_args(argv)
 


### PR DESCRIPTION
Lets you query for missing data:

```sh
$ get-data.py --show-missing
...
Missing blockfile 845869 00000000000000000000858fe3cb999f449bcbfcadd3bdb240641b6b9c39bb30
Missing blockfile 833411 000000000000000000018450917aeae08339ffd3172807420dd35c736032898f
Missing header 824221 00000000000000000003a0653dbab14cc0f6fef121442b29d6b4005cdcdbc0d5
...
```