### PR TITLE
get-data: skip new header without block

### DIFF
--- a/get-data.py
+++ b/get-data.py
@@ -83,6 +83,9 @@ def main(args):
         depth = tip["branchlen"]
         height = tip["height"]
         blockhash = tip["hash"]
+        if height > bci["blocks"]:
+            print(f"Skipping new header {blockhash} (height={height} > tip={bci['blocks']})")
+            continue
         while True:
             if height not in existing:
                 existing[height] = {}


### PR DESCRIPTION
I run get-data automatically to capture stale blocks on a pruned node, and was surprised to see that it grabbed block 914982 without any competing block at that height available. I think this is probably from the script happening to run between the header being received and the block being validated. This patch avoids adding an entry to the csv in that case.