### PR TITLE
fix: fetching raw blocks from mempool-space

### DIFF
--- a/ci/fetch-mempool-space.py
+++ b/ci/fetch-mempool-space.py
@@ -152,7 +152,7 @@ def main():
         if raw_block:
             with open(block_path, "wb") as f:
                 f.write(raw_block)
-            print(f"Saved raw block {block_hash} ({len(raw_block)} bytes)")
+            print(f"Saved raw block {hash} ({len(raw_block)} bytes)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The script previously failed with:
```
Run python3 ci/fetch-mempool-space.py
Fetched from https://mempool.space
Traceback (most recent call last):
  File "/home/runner/work/stale-blocks/stale-blocks/ci/fetch-mempool-space.py", line 159, in <module>
    main()
  File "/home/runner/work/stale-blocks/stale-blocks/ci/fetch-mempool-space.py", line 155, in main
    print(f"Saved raw block {block_hash} ({len(raw_block)} bytes)")
                             ^^^^^^^^^^
NameError: name 'block_hash' is not defined. Did you mean: 'block_path'?
```