### PR TITLE
CI improvements: retry transient HTTP errors and validate header PoW target

### DIFF
--- a/ci/no-main-chain-hash.py
+++ b/ci/no-main-chain-hash.py
@@ -5,16 +5,52 @@ import csv
 import json
 import sys
 import time
+import urllib.error
 from urllib.request import urlopen
+
+MAX_RETRIES = 5
+BASE_DELAY_S = 1.0
+RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
+
+
+def fetch_status(header_hash):
+    url = f"https://blockstream.info/api/block/{header_hash}/status"
+    for attempt in range(MAX_RETRIES):
+        try:
+            with urlopen(url, timeout=30) as response:
+                return json.loads(response.read())
+        except urllib.error.HTTPError as e:
+            if e.code in RETRYABLE_STATUSES and attempt < MAX_RETRIES - 1:
+                delay = BASE_DELAY_S * (2 ** attempt)
+                print(
+                    f"  HTTP {e.code} for {header_hash}, "
+                    f"retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRIES})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                continue
+            raise
+        except (urllib.error.URLError, TimeoutError) as e:
+            if attempt < MAX_RETRIES - 1:
+                delay = BASE_DELAY_S * (2 ** attempt)
+                print(
+                    f"  network error for {header_hash}: {e}, "
+                    f"retrying in {delay:.1f}s (attempt {attempt + 1}/{MAX_RETRIES})",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                continue
+            raise
+    raise RuntimeError(f"exhausted {MAX_RETRIES} retries for {header_hash}")
+
 
 reader = csv.reader(sys.stdin)
 next(reader, None)
 for row in reader:
     print("checking row:", row)
     header_hash = row[1]
-    with urlopen(f"https://blockstream.info/api/block/{header_hash}/status") as response:
-        response_content = json.loads(response.read())
-        assert not response_content["in_best_chain"]
+    response_content = fetch_status(header_hash)
+    assert not response_content["in_best_chain"]
     time.sleep(0.3)
 
 print("not-in-best-chain-check successful")

--- a/ci/sanity-check.py
+++ b/ci/sanity-check.py
@@ -4,7 +4,7 @@
 # - height is an integer > 0
 # - file is ordered by block height in descending order
 # - hash is 32-byte hex
-# - header is empty or 80-byte hex and hashes to hash
+# - header is empty or 80-byte hex, hashes to hash, and satisfies the PoW target encoded in nBits
 # - hashes are unique
 # - block files (if present) start with a matching 80-byte header
 # - missing/mismatching headers report the expected header
@@ -22,6 +22,17 @@ def dsha256(d):
     h1 = hashlib.sha256(d).digest()
     h2 = hashlib.sha256(h1).digest()
     return h2
+
+
+def target_from_bits(bits):
+    # Expand ordinary positive Bitcoin compact nBits values (4 bytes) to a
+    # 256-bit target integer. High byte is the size/exponent; low 3 bytes are
+    # the mantissa.
+    exponent = bits >> 24
+    mantissa = bits & 0x007FFFFF
+    if exponent <= 3:
+        return mantissa >> (8 * (3 - exponent))
+    return mantissa << (8 * (exponent - 3))
 
 
 def try_parse_hex(field, value, expected_len_bytes, context, problems, required=False):
@@ -80,6 +91,14 @@ with open("stale-blocks.csv", "r", newline="") as f:
                 calculated_header_hash = bytes(reversed(dsha256(header_bytes))).hex()
                 if header_hash != calculated_header_hash:
                     problems.append(f"stale-blocks.csv:{row_i}: header hash mismatch: {header_hash} != {calculated_header_hash}")
+                else:
+                    bits = int.from_bytes(header_bytes[72:76], "little")
+                    target = target_from_bits(bits)
+                    if int(calculated_header_hash, 16) > target:
+                        problems.append(
+                            f"stale-blocks.csv:{row_i}: header does not satisfy PoW target: "
+                            f"hash {calculated_header_hash} > target {target:064x} (nBits {bits:08x})"
+                        )
 
         hash_count[header_hash] = hash_count.get(header_hash, 0) + 1
 


### PR DESCRIPTION
## Summary

Two small CI hardening changes kept as separate commits.

The first wraps the `blockstream.info` fetch in `ci/no-main-chain-hash.py` in a retry helper with exponential backoff for transient HTTP/network failures - [a 429 from that API just broke a CI run on #94](https://github.com/bitcoin-data/stale-blocks/actions/runs/24653539860).

The second extends `ci/sanity-check.py` to verify `dsha256(header) ≤ target_from_bits(nBits)` for every row with a header, where `target_from_bits` expands ordinary positive Bitcoin `nBits` values into a full target integer. This closes a gap where a syntactically valid but low-work header would be accepted.

## Testing

New `ci/sanity-check.py` passes on `master` (1,208 headers, 1,038 blocks) and on the `add-namecoin-auxpow-stales` (#94) branch post-merge (2,297 headers, 1,038 blocks) with zero PoW-target failures. 

A one-bit nonce flip with the original CSV hash triggers the existing `header hash mismatch` failure; the same flip with the CSV hash updated to the mutated header triggers the new `header does not satisfy PoW target` failure. 

I did not try to reproduce the 429 directly since the failure is rate-dependent; the retry helper covers the standard retryable set (`429, 500, 502, 503, 504`, `URLError`, `TimeoutError`) and backs off 1s → 2s → 4s → 8s before propagating.
